### PR TITLE
Log on transfer failures

### DIFF
--- a/src/main/java/org/springframework/build/aws/maven/RetryingSimpleStorageWagon.java
+++ b/src/main/java/org/springframework/build/aws/maven/RetryingSimpleStorageWagon.java
@@ -106,7 +106,7 @@ public class RetryingSimpleStorageWagon extends SimpleStorageServiceWagon {
                  TRANSFER_ATTEMPTS,
                  TRANSFER_RETRY_WAIT_SECONDS);
       } else {
-        LOG.warn("Transfer attempt {}/{} failed.",
+        LOG.warn("Transfer attempt {}/{} failed. Will not retry",
                  attempt.getAttemptNumber(),
                  TRANSFER_ATTEMPTS);
       }

--- a/src/main/java/org/springframework/build/aws/maven/RetryingSimpleStorageWagon.java
+++ b/src/main/java/org/springframework/build/aws/maven/RetryingSimpleStorageWagon.java
@@ -96,22 +96,25 @@ public class RetryingSimpleStorageWagon extends SimpleStorageServiceWagon {
     public <V> void onRetry(Attempt<V> attempt) {
       if (attempt.hasResult()) {
         return;
-      } else if (attempt.getAttemptNumber() == TRANSFER_ATTEMPTS) {
-        LOG.warn("Transfer attempt {}/{} failed.",
-                 attempt.getAttemptNumber(),
-                 TRANSFER_ATTEMPTS);
-      } else {
-        LOG.warn("Transfer attempt {}/{} failed. Trying again in {} seconds",
+      }
+
+      boolean willRetry = attempt.getAttemptNumber() < TRANSFER_ATTEMPTS
+          && attempt.getExceptionCause() instanceof TransferFailedException;
+      if (willRetry) {
+        LOG.warn("Transfer attempt {}/{} failed. Retrying in {} seconds",
                  attempt.getAttemptNumber(),
                  TRANSFER_ATTEMPTS,
                  TRANSFER_RETRY_WAIT_SECONDS);
+      } else {
+        LOG.warn("Transfer attempt {}/{} failed.",
+                 attempt.getAttemptNumber(),
+                 TRANSFER_ATTEMPTS);
       }
-      if (attempt.hasException()) {
-        LOG.debug("Transfer attempt {}/{} failed with exception:",
-                  attempt.getAttemptNumber(),
-                  TRANSFER_ATTEMPTS,
-                  attempt.getExceptionCause());
-      }
+
+      LOG.debug("Transfer attempt {}/{} failed with exception:",
+                attempt.getAttemptNumber(),
+                TRANSFER_ATTEMPTS,
+                attempt.getExceptionCause());
     }
   }
 }


### PR DESCRIPTION
@jhaber 

Normally, it will look like
```
[WARNING] Transfer attempt 1/3 failed. Trying again in 5 seconds
[WARNING] Transfer attempt 2/3 failed. Trying again in 5 seconds
[WARNING] Transfer attempt 3/3 failed.
```

With the `-X` flag the exception-logging `LOG.debug` call will show up.