### PR TITLE
Add AmazonClientExceptions utility

### DIFF
--- a/src/main/java/org/springframework/build/aws/maven/AmazonClientExceptions.java
+++ b/src/main/java/org/springframework/build/aws/maven/AmazonClientExceptions.java
@@ -1,0 +1,64 @@
+package org.springframework.build.aws.maven;
+
+import org.apache.maven.wagon.ResourceDoesNotExistException;
+import org.apache.maven.wagon.TransferFailedException;
+import org.apache.maven.wagon.authorization.AuthorizationException;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.AmazonServiceException;
+
+public class AmazonClientExceptions {
+
+  private AmazonClientExceptions() {
+    throw new AssertionError();
+  }
+
+  public static RuntimeException propagateForRead(
+      AmazonClientException amazonClientException,
+      String s3Key
+  ) throws AuthorizationException, ResourceDoesNotExistException, TransferFailedException {
+    return propagate(amazonClientException, "Error reading '%s'", s3Key);
+  }
+
+  public static RuntimeException propagateForWrite(
+      AmazonClientException amazonClientException,
+      String s3Key
+  ) throws AuthorizationException, ResourceDoesNotExistException, TransferFailedException {
+    return propagate(amazonClientException, "Error writing '%s'", s3Key);
+  }
+
+  public static RuntimeException propagateForAccess(
+      AmazonClientException amazonClientException,
+      String s3Key
+  ) throws AuthorizationException, ResourceDoesNotExistException, TransferFailedException {
+    return propagate(amazonClientException, "Error accessing '%s'", s3Key);
+  }
+
+  // Note: this is not 100% well-defined given the potential error codes:
+  // http://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#ErrorCodeList
+  private static RuntimeException propagate(
+      AmazonClientException amazonClientException,
+      String errorMessageTemplate,
+      String s3Key
+  ) throws AuthorizationException, ResourceDoesNotExistException, TransferFailedException {
+    if (!(amazonClientException instanceof AmazonServiceException)) {
+      throw new TransferFailedException(
+          String.format(errorMessageTemplate, s3Key),
+          amazonClientException);
+    }
+    switch(((AmazonServiceException)amazonClientException).getStatusCode()) {
+    case 403:
+      throw new AuthorizationException(
+          String.format(errorMessageTemplate, s3Key),
+          amazonClientException);
+    case 404:
+      throw new ResourceDoesNotExistException(
+          String.format("'%s' does not exist", s3Key),
+          amazonClientException);
+    default:
+      throw new TransferFailedException(
+          String.format(errorMessageTemplate, s3Key),
+          amazonClientException);
+    }
+  }
+}

--- a/src/main/java/org/springframework/build/aws/maven/RetryingSimpleStorageWagon.java
+++ b/src/main/java/org/springframework/build/aws/maven/RetryingSimpleStorageWagon.java
@@ -34,7 +34,7 @@ public class RetryingSimpleStorageWagon extends SimpleStorageServiceWagon {
     super(amazonS3, bucketName, baseDirectory);
   }
 
-    @Override
+  @Override
   protected void putResource(
       final File source,
       final String destination,

--- a/src/test/java/org/springframework/build/aws/maven/AmazonClientExceptionsTest.java
+++ b/src/test/java/org/springframework/build/aws/maven/AmazonClientExceptionsTest.java
@@ -1,0 +1,45 @@
+package org.springframework.build.aws.maven;
+
+import org.apache.maven.wagon.ResourceDoesNotExistException;
+import org.apache.maven.wagon.TransferFailedException;
+import org.apache.maven.wagon.authorization.AuthorizationException;
+import org.junit.Test;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.AmazonServiceException;
+
+public class AmazonClientExceptionsTest {
+
+  @Test(expected = TransferFailedException.class)
+  public void itThrowsATransferFailedExceptionOnANonServiceException() throws Exception {
+    AmazonClientExceptions.propagateForAccess(new AmazonClientException("Test message"), "some/key");
+  }
+
+  @Test(expected = AuthorizationException.class)
+  public void itThrowsAnAuthorizationExceptionFor403() throws Exception {
+    createAndPropagateException(403, "AccessDenied", "some/key");
+  }
+
+  @Test(expected = ResourceDoesNotExistException.class)
+  public void itThrowsAResourceDoesNotExistExceptionOn403() throws Exception {
+    createAndPropagateException(404, "NoSuchKey", "some/key");
+  }
+
+  @Test(expected = TransferFailedException.class)
+  public void itThrowsATransferFailedExceptionOn500() throws Exception {
+    createAndPropagateException(500, "InternalError", "some/key");
+  }
+
+  private void createAndPropagateException(
+      int statusCode,
+      String errorCode,
+      String s3Key
+  ) throws Exception {
+    AmazonServiceException amazonServiceException =
+        new AmazonServiceException(String.format("%d: %s", statusCode, errorCode));
+    amazonServiceException.setStatusCode(statusCode);
+    amazonServiceException.setErrorCode(errorCode);
+
+    AmazonClientExceptions.propagateForAccess(amazonServiceException, s3Key);
+  }
+}


### PR DESCRIPTION
@jhaber lemme know what you think.

I'm not crazy about making such a big change in our fork, but the loss of information on the exceptions was making retrying on reads essentially impossible.

The three subclasses of `WagonException` that I throw here (`AuthorizationException`, `ResourceDoesNotExistException`, `TransferFailedException`) are the ones defined in the method signatures of the [`Wagon`](https://maven.apache.org/wagon/apidocs/org/apache/maven/wagon/Wagon.html) interface.

I can also see this change leading to retrying on more than just `putResource` and `getResource`