### PR TITLE
Upgrade to latest aws-java-sdk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	<description>Standard Maven wagon support for s3:// urls</description>
 
 	<properties>
-		<amazonaws.version>1.7.1</amazonaws.version>
+		<amazonaws.version>1.11.548</amazonaws.version>
 		<junit.version>4.11</junit.version>
 		<mockito.version>1.9.5</mockito.version>
 		<slf4j.version>1.7.6</slf4j.version>
@@ -23,24 +23,12 @@
 	<dependencies>
 		<dependency>
 			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk</artifactId>
+			<artifactId>aws-java-sdk-s3</artifactId>
 			<version>${amazonaws.version}</version>
 			<exclusions>
 				<exclusion>
 					<groupId>commons-logging</groupId>
 					<artifactId>commons-logging</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>javax.mail</groupId>
-					<artifactId>mail</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>stax</groupId>
-					<artifactId>stax-api</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>stax</groupId>
-					<artifactId>stax</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>

--- a/src/main/java/org/springframework/build/aws/maven/AuthenticationInfoAWSCredentialsProviderChain.java
+++ b/src/main/java/org/springframework/build/aws/maven/AuthenticationInfoAWSCredentialsProviderChain.java
@@ -16,18 +16,19 @@
 
 package org.springframework.build.aws.maven;
 
+import org.apache.maven.wagon.authentication.AuthenticationInfo;
+
 import com.amazonaws.auth.AWSCredentialsProviderChain;
 import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
 import com.amazonaws.auth.InstanceProfileCredentialsProvider;
 import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
-import org.apache.maven.wagon.authentication.AuthenticationInfo;
 
 final class AuthenticationInfoAWSCredentialsProviderChain extends AWSCredentialsProviderChain {
 
     AuthenticationInfoAWSCredentialsProviderChain(AuthenticationInfo authenticationInfo) {
         super(new EnvironmentVariableCredentialsProvider(),
                 new SystemPropertiesCredentialsProvider(),
-                new InstanceProfileCredentialsProvider(),
+                InstanceProfileCredentialsProvider.getInstance(),
                 new AuthenticationInfoAWSCredentialsProvider(authenticationInfo));
     }
 }


### PR DESCRIPTION
This upgrades to the latest aws-java-sdk so that it uses SignatureV4 ahead of the deadline

@stevegutz @kmclarnon 